### PR TITLE
The newest version of express is not compatible 

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "express": "latest",
+    "express": "3.5.2",
     "jade": "latest",
     "socket.io": "latest"
   },


### PR DESCRIPTION
This is a really cool project. Thanks for getting it going.

In the [4.0 release of expressjs](https://github.com/visionmedia/express/blob/master/History.md#400--2014-04-09) most of the middleware was removed and now must be installed separately. As a quick fix I just set the expressjs version to the last 3.x release to ensures that the middleware used in this project will be included. I mostly just wanted to bring this up as an issue, but thought it was worth including a stop gap fix too. It would be better to have the middleware installed separately and continue using the latest expressjs version rather than accepting my pull request, but maybe this is a good quick fix for now. I'll poke around a bit more later when I have some more time too. Thanks again for the project.
