### PR TITLE
allow all room connections to receive captions

### DIFF
--- a/Components/Socket/index.js
+++ b/Components/Socket/index.js
@@ -20,7 +20,7 @@ var Socket = function(io) {
 	};
 
 	var newCaptionHandler = function(data) {
-		sock.broadcast.to(data.room).emit("new caption", data.text);
+		io.sockets.in(data.room).emit("new caption", data.text);
 	};
 
 	var getRoomNameHandler = function(data) {


### PR DESCRIPTION
This fixes #10.
I tested by opening a few new rooms and taking turns to broadcast captions around and the rooms only received the captions from their own room, so to speak. So working as expected 👍